### PR TITLE
Dockerfile: add libc6-compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/celestiaorg/celestia-app:v0.11.0
 
 COPY --from=celestia-node /celestia /
 
-RUN apk update && apk --no-cache add curl jq
+RUN apk update && apk --no-cache add curl jq libc6-compat
 
 COPY wait-for-it.sh /
 


### PR DESCRIPTION
## Overview

The docker image fails to run on linux or intel macs with:

    ./celestia: not found

It seems that to run go binaries on alpine you also need `libc6-compat`. Adding this resolves the issue.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
